### PR TITLE
Fix for dependency ordering issue

### DIFF
--- a/manifests/web/config.pp
+++ b/manifests/web/config.pp
@@ -11,7 +11,8 @@ class graphite::web::config {
     group     => 'root',
     mode      => '0644',
     notify    => Service[$service_name],
-    content   => template('graphite/local_settings.py.erb');
+    content   => template('graphite/local_settings.py.erb'),
+    require   => Package['graphite-web'],
   }
 
   if $::osfamily == 'Debian' {


### PR DESCRIPTION
Noticed this when running vagrant-graphite locally.  The first run always fails for me, since graphite yet hasn't been installed.
