### PR TITLE
Updated modulefile to use puppetlabs/concat

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -4,7 +4,7 @@ source 'github'
 author 'Kris Buytaert'
 license 'GPL'
 summary 'This module installs and configures graphite'
-project_page ''
+project_page 'https://github.com/KrisBuytaert/puppet-graphite'
 
 ## Add dependencies, if any:
-dependency 'ripienaar/concat', '>= 0.1.0'
+dependency 'puppetlabs/concat', '>= 1.0.0'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Dependencies
 ------------
 This module depends on
 
-- [concat](http://forge.puppetlabs.com/ripienaar/concat)
+- [concat](http://forge.puppetlabs.com/puppetlabs/concat)
 
 Installation
 ------------


### PR DESCRIPTION
puppetlabs/concat is now the the canonical source for concat. This version will be stable, and it won't conflict now with other modules that need concat from puppetlabs.
