### PR TITLE
Update upstream

### DIFF
--- a/manifests/carbon.pp
+++ b/manifests/carbon.pp
@@ -130,6 +130,7 @@ class graphite::carbon (
   $relay_use_flow_control                    = $graphite::params::relay_use_flow_control,
   $relay_use_whitelist                       = $graphite::params::relay_use_whitelist,
   $relay_user                                = $graphite::params::relay_user,
+  $relay_ulimit_nofile                       = $graphite::params::relay_ulimit_nofile,
   $whisper_dir                               = $graphite::params::whisper_dir,
   $web_allowed_hosts                         = $graphite::params::web_allowed_hosts,
   $web_basic_http_auth                       = $graphite::params::web_basic_http_auth,

--- a/manifests/carbon.pp
+++ b/manifests/carbon.pp
@@ -130,7 +130,6 @@ class graphite::carbon (
   $relay_use_flow_control                    = $graphite::params::relay_use_flow_control,
   $relay_use_whitelist                       = $graphite::params::relay_use_whitelist,
   $relay_user                                = $graphite::params::relay_user,
-  $relay_ulimit_nofile                       = $graphite::params::relay_ulimit_nofile,
   $whisper_dir                               = $graphite::params::whisper_dir,
   $web_allowed_hosts                         = $graphite::params::web_allowed_hosts,
   $web_basic_http_auth                       = $graphite::params::web_basic_http_auth,

--- a/manifests/carbon.pp
+++ b/manifests/carbon.pp
@@ -78,6 +78,7 @@ class graphite::carbon (
   $carbon_amqp_vhost                         = $graphite::params::carbon_amqp_vhost,
   $carbon_bind_patterns                      = $graphite::params::carbon_bind_patterns,
   $carbon_cache_amount                       = $graphite::params::carbon_cache_amount,
+  $carbon_cache_query_interface              = $graphite::params::carbon_cache_query_interface,
   $carbon_cache_query_port                   = $graphite::params::carbon_cache_query_port,
   $carbon_cache_service_ensure               = $graphite::params::carbon_cache_service_ensure,
   $carbon_cache_service_name                 = $graphite::params::carbon_cache_service_name,
@@ -88,6 +89,7 @@ class graphite::carbon (
   $carbon_enable_amqp                        = $graphite::params::carbon_enable_amqp,
   $carbon_enable_logrotation                 = $graphite::params::carbon_enable_logrotation,
   $carbon_enable_udp_listerner               = $graphite::params::carbon_enable_udp_listerner,
+  $carbon_line_receiver_interface            = $graphite::params::carbon_line_receiver_interface,
   $carbon_line_receiver_port                 = $graphite::params::carbon_line_receiver_port,
   $carbon_log_cache_hits                     = $graphite::params::carbon_log_cache_hits,
   $carbon_log_cache_queu_sorts               = $graphite::params::carbon_log_cache_queu_sorts,
@@ -99,7 +101,9 @@ class graphite::carbon (
   $carbon_max_updates_per_second_on_shutdown = $graphite::params::carbon_max_updates_per_second_on_shutdown,
   $carbon_package                            = $graphite::params::carbon_package,
   $carbon_package_ensure                     = $graphite::params::carbon_package_ensure,
+  $carbon_pickle_receiver_interface          = $graphite::params::carbon_pickle_receiver_interface,
   $carbon_pickle_receiver_port               = $graphite::params::carbon_pickle_receiver_port,
+  $carbon_udp_receiver_interface             = $graphite::params::carbon_udp_receiver_interface,
   $carbon_udp_receiver_port                  = $graphite::params::carbon_udp_receiver_port,
   $carbon_use_flow_control                   = $graphite::params::carbon_use_flow_control,
   $carbon_use_insecure_unpickler             = $graphite::params::carbon_use_insecure_unpickler,
@@ -119,6 +123,7 @@ class graphite::carbon (
   $relay_log_listener_connections            = $graphite::params::relay_log_listener_connections,
   $relay_max_data_points_per_message         = $graphite::params::relay_max_data_points_per_message,
   $relay_max_queue_size                      = $graphite::params::relay_max_queue_size,
+  $relay_method                              = $graphite::params::relay_method,
   $relay_pickle_receiver_interface           = $graphite::params::relay_pickle_receiver_interface,
   $relay_pickle_receiver_port                = $graphite::params::relay_pickle_receiver_port,
   $relay_replication_factor                  = $graphite::params::relay_replication_factor,
@@ -165,19 +170,6 @@ class graphite::carbon (
   $web_user                                  = $graphite::params::web_user,
 ) inherits ::graphite {
 
-  if $carbon_cache_amount > 1 {
-      $carbon_line_receiver_interface   = '127.0.0.1'
-      $carbon_udp_receiver_interface    = '127.0.0.1'
-      $carbon_pickle_receiver_interface = '127.0.0.1'
-      $carbon_cache_query_interface     = '127.0.0.1'
-      $relay_method                     = 'consistent-hashing'
-    } else {
-      $carbon_line_receiver_interface   = '0.0.0.0'
-      $carbon_udp_receiver_interface    = '0.0.0.0'
-      $carbon_pickle_receiver_interface = '0.0.0.0'
-      $carbon_cache_query_interface     = '0.0.0.0'
-      $relay_method                     = 'rules'
-    }
 
   contain graphite::carbon::package
   contain graphite::carbon::config

--- a/manifests/carbon/config.pp
+++ b/manifests/carbon/config.pp
@@ -121,8 +121,7 @@ class graphite::carbon::config inherits graphite::carbon {
     owner   => 'root',
     mode    => '0755',
     content => template('graphite/relay/carbon-relay.systemd.erb'),
-    require => Package[$graphite::carbon::carbon_package],
-    notify  => Service[$graphite::carbon::carbon_cache_service_name],
+    notify  => Service[$graphite::carbon::relay_service_name],
   }
 
   if ($graphite::relay::relay_method == 'rules') {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,6 +86,7 @@ class graphite (
   $relay_use_flow_control                    = $::graphite::params::relay_use_flow_control,
   $relay_use_whitelist                       = $::graphite::params::relay_use_whitelist,
   $relay_user                                = $::graphite::params::relay_user,
+  $relay_ulimit_nofile                       = $::graphite::params::relay_ulimit_nofile,
   $web_allowed_hosts                         = $::graphite::params::web_allowed_hosts,
   $web_basic_http_auth                       = $::graphite::params::web_basic_http_auth,
   $web_basic_http_auth_password              = $::graphite::params::web_basic_http_auth_password,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,7 +86,6 @@ class graphite (
   $relay_use_flow_control                    = $::graphite::params::relay_use_flow_control,
   $relay_use_whitelist                       = $::graphite::params::relay_use_whitelist,
   $relay_user                                = $::graphite::params::relay_user,
-  $relay_ulimit_nofile                       = $::graphite::params::relay_ulimit_nofile,
   $web_allowed_hosts                         = $::graphite::params::web_allowed_hosts,
   $web_basic_http_auth                       = $::graphite::params::web_basic_http_auth,
   $web_basic_http_auth_password              = $::graphite::params::web_basic_http_auth_password,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,7 +56,7 @@ class graphite::params (
   $carbon_amqp_verbose                       = 'False',
   $carbon_amqp_vhost                         = '/',
   $carbon_cache_amount                       = $::processorcount,
-  $carbon_cache_query_interface              = '0.0.0.0'
+  $carbon_cache_query_interface              = '0.0.0.0',
   $carbon_cache_query_port                   = '7002',
   $carbon_cache_service_enable               = 'running',
   $carbon_cache_service_name                 = 'carbon-cache',
@@ -65,7 +65,7 @@ class graphite::params (
   $carbon_enable_amqp                        = 'False',
   $carbon_enable_logrotation                 = 'False',
   $carbon_enable_udp_listerner               = 'False',
-  $carbon_line_receiver_interface            = '0.0.0.0'
+  $carbon_line_receiver_interface            = '0.0.0.0',
   $carbon_line_receiver_port                 = '2013',
   $carbon_log_cache_hits                     = 'False',
   $carbon_log_cache_queu_sorts               = 'True',
@@ -78,7 +78,7 @@ class graphite::params (
   $carbon_package_ensure                     = 'present',
   $carbon_pickle_receiver_interface          = '0.0.0.0',
   $carbon_pickle_receiver_port               = '2015',
-  $carbon_udp_receiver_interface             = '0.0.0.0'
+  $carbon_udp_receiver_interface             = '0.0.0.0',
   $carbon_udp_receiver_port                  = '2014',
   $carbon_use_flow_control                   = 'True',
   $carbon_use_insecure_unpickler             = 'False',
@@ -92,7 +92,7 @@ class graphite::params (
   $relay_log_listener_connections            = 'True',
   $relay_max_data_points_per_message         = '500',
   $relay_max_queue_size                      = '10000',
-  $$relay_method                             = 'rules',
+  $relay_method                             = 'rules',
   $relay_pickle_receiver_interface           = '0.0.0.0',
   $relay_pickle_receiver_port                = '2004',
   $relay_replication_factor                  = '1',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,6 +100,7 @@ class graphite::params (
   $relay_service_name                        = 'carbon-relay',
   $relay_use_flow_control                    = 'True',
   $relay_user                                = 'carbon',
+  $relay_ulimit_nofile                       = undef,
   $web_basic_http_auth                       = false,
   $web_conf_dir                              = '/etc/graphite-web',
   $web_content_dir                           = '/usr/share/graphite/webapp/content',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,7 +100,6 @@ class graphite::params (
   $relay_service_name                        = 'carbon-relay',
   $relay_use_flow_control                    = 'True',
   $relay_user                                = 'carbon',
-  $relay_ulimit_nofile                       = undef,
   $web_basic_http_auth                       = false,
   $web_conf_dir                              = '/etc/graphite-web',
   $web_content_dir                           = '/usr/share/graphite/webapp/content',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,6 +56,7 @@ class graphite::params (
   $carbon_amqp_verbose                       = 'False',
   $carbon_amqp_vhost                         = '/',
   $carbon_cache_amount                       = $::processorcount,
+  $carbon_cache_query_interface              = '0.0.0.0'
   $carbon_cache_query_port                   = '7002',
   $carbon_cache_service_enable               = 'running',
   $carbon_cache_service_name                 = 'carbon-cache',
@@ -64,6 +65,7 @@ class graphite::params (
   $carbon_enable_amqp                        = 'False',
   $carbon_enable_logrotation                 = 'False',
   $carbon_enable_udp_listerner               = 'False',
+  $carbon_line_receiver_interface            = '0.0.0.0'
   $carbon_line_receiver_port                 = '2013',
   $carbon_log_cache_hits                     = 'False',
   $carbon_log_cache_queu_sorts               = 'True',
@@ -74,7 +76,9 @@ class graphite::params (
   $carbon_max_updates_per_second             = '500',
   $carbon_package                            = 'python-carbon',
   $carbon_package_ensure                     = 'present',
+  $carbon_pickle_receiver_interface          = '0.0.0.0',
   $carbon_pickle_receiver_port               = '2015',
+  $carbon_udp_receiver_interface             = '0.0.0.0'
   $carbon_udp_receiver_port                  = '2014',
   $carbon_use_flow_control                   = 'True',
   $carbon_use_insecure_unpickler             = 'False',
@@ -88,6 +92,7 @@ class graphite::params (
   $relay_log_listener_connections            = 'True',
   $relay_max_data_points_per_message         = '500',
   $relay_max_queue_size                      = '10000',
+  $$relay_method                             = 'rules',
   $relay_pickle_receiver_interface           = '0.0.0.0',
   $relay_pickle_receiver_port                = '2004',
   $relay_replication_factor                  = '1',

--- a/manifests/relay.pp
+++ b/manifests/relay.pp
@@ -49,7 +49,6 @@ class graphite::relay (
   $relay_use_flow_control            = $graphite::params::relay_use_flow_control,
   $relay_use_whitelist               = $graphite::params::relay_use_whitelist,
   $relay_user                        = $graphite::params::relay_user,
-  $relay_ulimit_nofile               = $graphite::params::relay_ulimit_nofile,
 ) inherits graphite::params {
   contain graphite::relay::config
   contain graphite::relay::package

--- a/manifests/relay.pp
+++ b/manifests/relay.pp
@@ -49,6 +49,7 @@ class graphite::relay (
   $relay_use_flow_control            = $graphite::params::relay_use_flow_control,
   $relay_use_whitelist               = $graphite::params::relay_use_whitelist,
   $relay_user                        = $graphite::params::relay_user,
+  $relay_ulimit_nofile               = $graphite::params::relay_ulimit_nofile,
 ) inherits graphite::params {
   contain graphite::relay::config
   contain graphite::relay::package

--- a/manifests/relay.pp
+++ b/manifests/relay.pp
@@ -26,6 +26,10 @@
 #   carbon_pickle_receiver_port => '2012',
 # }
 #
+# Use destinations with different ports:
+# class { 'graphite::relay':
+#   relay_destinations          => ['192.168.1.102:2015','192.168.1.104:2025'],
+
 class graphite::relay (
   $relay_method                      = 'consistent-hashing',
   $carbon_pickle_receiver_port       = $graphite::params::relay_pickle_receiver_port,

--- a/manifests/relay/config.pp
+++ b/manifests/relay/config.pp
@@ -52,6 +52,26 @@ class graphite::relay::config inherits graphite::relay {
     notify  => Service[$graphite::relay::relay_service_name],
   }
 
+  # Systemd service
+  file {'/etc/systemd/system/carbon-relay.service':
+    ensure  => present,
+    group   => 'root',
+    owner   => 'root',
+    mode    => '0755',
+    content => template('graphite/relay/carbon-relay.systemd.erb'),
+    require => Package[$graphite::carbon::carbon_package],
+    notify  => Service[$graphite::carbon::carbon_cache_service_name],
+  }
+  file {'/etc/systemd/system/carbon-relay@.service':
+    ensure  => present,
+    group   => 'root',
+    owner   => 'root',
+    mode    => '0755',
+    content => template('graphite/relay/carbon-relay@.systemd.erb'),
+    require => Package[$graphite::carbon::carbon_package],
+    notify  => Service[$graphite::carbon::carbon_cache_service_name],
+  }
+
   notify { 'debug':
     message => "relay_method = ${relay_method}",
   }

--- a/manifests/relay/config.pp
+++ b/manifests/relay/config.pp
@@ -59,8 +59,8 @@ class graphite::relay::config inherits graphite::relay {
     owner   => 'root',
     mode    => '0755',
     content => template('graphite/relay/carbon-relay.systemd.erb'),
-    require => Package[$graphite::carbon::carbon_package],
-    notify  => Service[$graphite::carbon::carbon_cache_service_name],
+    require => Package[$graphite::relay::carbon_package],
+    notify  => Service[$graphite::relay::relay_service_name],
   }
   file {'/etc/systemd/system/carbon-relay@.service':
     ensure  => present,
@@ -68,8 +68,8 @@ class graphite::relay::config inherits graphite::relay {
     owner   => 'root',
     mode    => '0755',
     content => template('graphite/relay/carbon-relay@.systemd.erb'),
-    require => Package[$graphite::carbon::carbon_package],
-    notify  => Service[$graphite::carbon::carbon_cache_service_name],
+    require => Package[$graphite::relay::carbon_package],
+    notify  => Service[$graphite::relay::relay_service_name],
   }
 
   notify { 'debug':

--- a/manifests/relay/config.pp
+++ b/manifests/relay/config.pp
@@ -72,10 +72,6 @@ class graphite::relay::config inherits graphite::relay {
     notify  => Service[$graphite::relay::relay_service_name],
   }
 
-  notify { 'debug':
-    message => "relay_method = ${relay_method}",
-  }
-
   if ($graphite::relay::relay_method == 'rules') {
     file { "${graphite::relay::carbon_config_dir}relay-rules.conf":
       ensure  => present,

--- a/templates/carbon/carbon-cache.systemd.erb
+++ b/templates/carbon/carbon-cache.systemd.erb
@@ -1,0 +1,14 @@
+[Unit]
+Description=Graphite Carbon Cache
+After=network.target
+
+[Service]
+Type=forking
+StandardOutput=syslog
+StandardError=syslog
+ExecStart=/usr/bin/carbon-cache --config=<%= @carbon_config_dir %>carbon-cache.conf --pidfile=/var/run/carbon-cache.pid --logdir=/var/log/carbon/ start
+ExecReload=/bin/kill -USR1 $MAINPID
+PIDFile=/var/run/carbon-cache.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/carbon/carbon-cache@.systemd.erb
+++ b/templates/carbon/carbon-cache@.systemd.erb
@@ -1,0 +1,15 @@
+[Unit]
+Description=Graphite Carbon Cache Instance <%= @number %>
+After=network.target
+
+[Service]
+Type=forking
+StandardOutput=syslog
+StandardError=syslog
+ExecStart=/usr/bin/carbon-cache --config=<%= @carbon_config_dir %>carbon-cache.conf --pidfile=/var/run/carbon-cache-<%= @number %>.pid --logdir=/var/log/carbon/ --instance=<%= @number %> start
+ExecReload=/bin/kill -USR1 $MAINPID
+PIDFile=/var/run/carbon-cache-<%= @number %>.pid
+
+[Install]
+WantedBy=multi-user.target
+DefaultInstance=1

--- a/templates/relay/carbon-relay.conf.erb
+++ b/templates/relay/carbon-relay.conf.erb
@@ -12,6 +12,9 @@ LINE_RECEIVER_PORT = <%= @relay_line_receiver_port %>
 PICKLE_RECEIVER_INTERFACE = <%= @relay_pickle_receiver_interface %>
 PICKLE_RECEIVER_PORT = <%= @relay_pickle_receiver_port %>
 
+# Enable daily log rotation. If disabled, a kill -HUP can be used after a manual rotate
+ENABLE_LOGROTATION = False
+
 # Set to false to disable logging of successful connections
 LOG_LISTENER_CONNECTIONS = <%= @relay_log_listener_connections %>
 

--- a/templates/relay/carbon-relay.conf.erb
+++ b/templates/relay/carbon-relay.conf.erb
@@ -55,7 +55,11 @@ REPLICATION_FACTOR = <%= @relay_replication_factor %>
 destinations = ''
 i = 1
 for d in @relay_destinations do
-  destinations += (d +':'+ @relay_pickle_receiver_port)
+  if d.include? ":"
+    destinations += d
+  else
+    destinations += (d +':'+ @relay_pickle_receiver_port)
+  end
   if i < @relay_destinations.length
     destinations += ', '
   end

--- a/templates/relay/carbon-relay.systemd.erb
+++ b/templates/relay/carbon-relay.systemd.erb
@@ -9,6 +9,9 @@ StandardError=syslog
 ExecStart=/usr/bin/carbon-relay --config=<%= @carbon_config_dir %>carbon-relay.conf --pidfile=/var/run/carbon-relay.pid --logdir=/var/log/carbon/ start
 ExecReload=/bin/kill -USR1 $MAINPID
 PIDFile=/var/run/carbon-relay.pid
+<% if @relay_ulimit_nofile -%>
+LimitNOFILE=<%= @relay_ulimit_nofile %>
+<% end -%>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/relay/carbon-relay.systemd.erb
+++ b/templates/relay/carbon-relay.systemd.erb
@@ -1,0 +1,14 @@
+[Unit]
+Description=Graphite Carbon Relay
+After=network.target
+
+[Service]
+Type=forking
+StandardOutput=syslog
+StandardError=syslog
+ExecStart=/usr/bin/carbon-relay --config=<%= @carbon_config_dir %>carbon-relay.conf --pidfile=/var/run/carbon-relay.pid --logdir=/var/log/carbon/ start
+ExecReload=/bin/kill -USR1 $MAINPID
+PIDFile=/var/run/carbon-relay.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/relay/carbon-relay.systemd.erb
+++ b/templates/relay/carbon-relay.systemd.erb
@@ -9,9 +9,6 @@ StandardError=syslog
 ExecStart=/usr/bin/carbon-relay --config=<%= @carbon_config_dir %>carbon-relay.conf --pidfile=/var/run/carbon-relay.pid --logdir=/var/log/carbon/ start
 ExecReload=/bin/kill -USR1 $MAINPID
 PIDFile=/var/run/carbon-relay.pid
-<% if @relay_ulimit_nofile -%>
-LimitNOFILE=<%= @relay_ulimit_nofile %>
-<% end -%>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/relay/carbon-relay@.systemd.erb
+++ b/templates/relay/carbon-relay@.systemd.erb
@@ -1,0 +1,15 @@
+[Unit]
+Description=Graphite Carbon Relay Instance %I
+After=network.target
+
+[Service]
+Type=forking
+StandardOutput=syslog
+StandardError=syslog
+ExecStart=/usr/bin/carbon-relay -config=<%= @carbon_config_dir %>carbon-relay.conf --pidfile=/var/run/carbon-relay-%i.pid --logdir=/var/log/carbon/ --instance=%i start
+ExecReload=/bin/kill -USR1 $MAINPID
+PIDFile=/var/run/carbon-relay-%i.pid
+
+[Install]
+WantedBy=multi-user.target
+DefaultInstance=1


### PR DESCRIPTION
- Systemd template added
- Carbon cache and relay's systemd configuration added
- Correct require and notify for relay
- allow specific port for relay destination
- get rid of hardcoded values in carbon.pp
- fix params.pp
- remove notify {} for debugging
- relay: disable logrotation by carbon itself